### PR TITLE
Update URL for onnx model download

### DIFF
--- a/generate_properties.py
+++ b/generate_properties.py
@@ -278,7 +278,7 @@ def main():
 
     # download vggnet 16 if needed
     if not os.path.exists('onnx/vgg16-7.onnx'):
-        os.system("wget https://github.com/onnx/models/raw/main/vision/classification/vgg/model/vgg16-7.onnx -O onnx/vgg16-7.onnx")
+        os.system("wget https://github.com/onnx/models/raw/main/archive/vision/classification/vgg/model/vgg16-7.onnx -O onnx/vgg16-7.onnx")
 
     onnx_filename = 'onnx/vgg16-7.onnx'
     image_dir = "imagenet-sample"


### PR DESCRIPTION
The ONNX repository has been reorganised, so the link to the onnx model needs to be updated for the download to work.